### PR TITLE
GKE terraform doc fixes

### DIFF
--- a/gke/README.md
+++ b/gke/README.md
@@ -13,5 +13,5 @@
 
 3. `terraform plan -out <path-to-save-plan>`
 
-4. `terraform apply plan <path-to-saved-plan>`
-  
+4. `terraform apply <path-to-saved-plan>`
+

--- a/gke/terraform.tfvars.template
+++ b/gke/terraform.tfvars.template
@@ -1,7 +1,7 @@
 project             =   "placeholder" #GCP project id
 location            =   "placeholder" #GCP region
-node-pool-name      =   "placeholder" #Name for your nodepool
-vm_type             =   "placeholder" #e.g: Ubuntu
+node_pool_name      =   "placeholder" #Name for your nodepool
+vm_type             =   "placeholder" #e.g: UBUNTU
 gke_sa_key          =   "placeholder" #path to your service account key
 gcp_dns_sa_key      =   "placeholder" #path to your dns service account key
-cluster_lables      =   "{key = "placeholder"}" #labels to be attached to cluster
+cluster_labels      =   {key = "placeholder"} #labels to be attached to cluster


### PR DESCRIPTION
- Update terraform tfvars template key names & value placeholders
- Remove erroneous 'plan' from 'terraform apply' in README