### PR TITLE
Fix for external-dns DNS resource group.

### DIFF
--- a/aks/external-dns.tf
+++ b/aks/external-dns.tf
@@ -17,6 +17,7 @@ resource "helm_release" "external-dns" {
         name = "azure.secretName"
         value = "${kubernetes_secret.azure_dns_sp_creds.metadata.0.name}"
     }
+    
     set {
         name = "provider"
         value = "azure"
@@ -26,6 +27,7 @@ resource "helm_release" "external-dns" {
         name = "azure.resourceGroup"
         value = "${var.dns_zone_rg}"
     }
+    
     set {
         name = "logLevel"
         value = "debug"

--- a/aks/external-dns.tf
+++ b/aks/external-dns.tf
@@ -23,6 +23,10 @@ resource "helm_release" "external-dns" {
     }
 
     set {
+        name = "azure.resourceGroup"
+        value = "${var.dns_zone_rg}"
+    }
+    set {
         name = "logLevel"
         value = "debug"
     }

--- a/aks/main.tf
+++ b/aks/main.tf
@@ -32,6 +32,8 @@ resource "azurerm_kubernetes_cluster" "k8s" {
         client_secret = "${var.client_secret}"
     }
 
+    kubernetes_version = "${var.k8s_version}"
+    
     tags = "${var.cluster_labels}"
 }
 

--- a/aks/main.tf
+++ b/aks/main.tf
@@ -10,7 +10,6 @@ resource "azurerm_kubernetes_cluster" "k8s" {
     location            = "${var.location}"
     resource_group_name = "${var.az_resource_group}"
     dns_prefix          = "${var.dns_prefix}"
-    kubernetes_version  = "${var.k8s_version}"
 
     linux_profile {
         admin_username = "${var.agent_admin}"

--- a/aks/variables.tf
+++ b/aks/variables.tf
@@ -53,6 +53,10 @@ variable "chart_values_file" {
     type = "string"
 }
 
+variable "k8s_version" {
+    type = "string"
+}
+
 
 
 

--- a/aks/variables.tf
+++ b/aks/variables.tf
@@ -25,9 +25,6 @@ variable "cluster_labels" {
     type = "map"
 }
 
-variable "k8s_version" {
-    default = "1.13.5"
-}
 variable "disk_size_gb" {
     default = 60
 }

--- a/aks/variables.tf
+++ b/aks/variables.tf
@@ -10,7 +10,7 @@ variable "node_count" {
     default = "1"
 }
 variable "machine_type" {
-    default = "Standard_DS3_v2"
+    default = "Standard_DS4_v2"
 }
 
 variable "agent_admin" {

--- a/aks/variables.tf
+++ b/aks/variables.tf
@@ -45,9 +45,9 @@ variable "azure_dns_json" {
     type = "string"
 }
 
-#variable "scf_domain" {
-#    type = "string"
-#}
+variable "dns_zone_rg" {
+    type = "string"
+}
 #
 variable "chart_values_file" {
     type = "string"


### PR DESCRIPTION
Now, external-dns needs to have the DNS zone resource group specified as a helm values parameter even though this is already specified in the service principal json file.

https://github.com/helm/charts/blob/3055e72254aeb622899d288b0dbc55de7af040ad/stable/external-dns/templates/_helpers.tpl#L279

Note that other parameters such as tenant id, subscription id can still be pulled from the service principal json file and not specified separately:

https://github.com/helm/charts/blob/3055e72254aeb622899d288b0dbc55de7af040ad/stable/external-dns/templates/_helpers.tpl#L291
