### PR TITLE
Fix external dns helm values and k8s version

### DIFF
--- a/aks/external-dns.tf
+++ b/aks/external-dns.tf
@@ -34,3 +34,4 @@ resource "helm_release" "external-dns" {
 
     depends_on = ["kubernetes_cluster_role_binding.tiller"]
 }
+

--- a/aks/external-dns.tf
+++ b/aks/external-dns.tf
@@ -23,6 +23,11 @@ resource "helm_release" "external-dns" {
     }
 
     set {
+        name = "azure.resourceGroup"
+        value = "${var.dns_zone_rg}"
+    }
+
+    set {
         name = "logLevel"
         value = "debug"
     }

--- a/aks/main.tf
+++ b/aks/main.tf
@@ -10,6 +10,7 @@ resource "azurerm_kubernetes_cluster" "k8s" {
     location            = "${var.location}"
     resource_group_name = "${var.az_resource_group}"
     dns_prefix          = "${var.dns_prefix}"
+    kubernetes_version  = "${var.k8s_version}"
 
     linux_profile {
         admin_username = "${var.agent_admin}"

--- a/aks/variables.tf
+++ b/aks/variables.tf
@@ -48,3 +48,7 @@ variable "azure_dns_json" {
 variable "k8s_version" {
     type = "string"
 }
+
+variable "dns_zone_rg" {
+    type="string"
+}

--- a/aks/variables.tf
+++ b/aks/variables.tf
@@ -45,6 +45,6 @@ variable "azure_dns_json" {
     type = "string"
 }
 
-
-
-
+variable "k8s_version" {
+    type = "string"
+}


### PR DESCRIPTION
Address what appears to be a regression in external-dns which requires specifying the resource group of the Azure DNS zone in external-dns helm chart values in-spite of the same resource group being specified in a secret.