### PR TITLE
Consistently use abstracted variable names for cluster sizing

### DIFF
--- a/aks/main.tf
+++ b/aks/main.tf
@@ -22,8 +22,8 @@ resource "azurerm_kubernetes_cluster" "k8s" {
 
     agent_pool_profile {
         name            = "agentpool"
-        count           = "${var.node_count}"
-        vm_size         = "${var.machine_type}"
+        count           = "${var.instance_count}"
+        vm_size         = "${var.instance_type}"
         os_type         = "Linux"
         os_disk_size_gb = "${var.disk_size_gb}"
     }

--- a/aks/variables.tf
+++ b/aks/variables.tf
@@ -6,10 +6,10 @@ variable "location" {
     type = "string"
 }
 
-variable "node_count" {
+variable "instance_count" {
     default = "1"
 }
-variable "machine_type" {
+variable "instance_type" {
     default = "Standard_DS4_v2"
 }
 

--- a/gke/main.tf
+++ b/gke/main.tf
@@ -45,11 +45,11 @@ resource "google_container_node_pool" "np" {
   name       = "${var.node_pool_name}"
   location   = "${var.location}"
   cluster    = "${google_container_cluster.gke-cluster.name}"
-  node_count = "${var.node_count}"
+  node_count = "${var.instance_count}"
 
   node_config {
     preemptible  = false
-    machine_type = "${var.machine_type}"
+    machine_type = "${var.instance_type}"
     disk_size_gb = "${var.disk_size_gb}"
     image_type   = "${var.vm_type}"
 
@@ -79,7 +79,7 @@ resource "null_resource" "post_processor" {
     environment = {
       CLUSTER_NAME = "${google_container_cluster.gke-cluster.name}"
       CLUSTER_ZONE = "${var.location}"
-      NODE_COUNT   = "${var.node_count}"
+      NODE_COUNT   = "${var.instance_count}"
       SA_KEY_FILE  = "${var.gke_sa_key}"
     }
   }

--- a/gke/variables.tf
+++ b/gke/variables.tf
@@ -10,10 +10,10 @@ variable "node_pool_name" {
     type = "string"
 }
 
-variable "node_count" {
+variable "instance_count" {
     default = "3"
 }
-variable "machine_type" {
+variable "instance_type" {
     default = "n1-standard-4"
 }
 
@@ -40,8 +40,3 @@ variable "gcp_dns_sa_key" {
 variable "k8s_version" {
     type = "string"
 }
-
-
-
-
-


### PR DESCRIPTION
The 'node_count' and 'machine_type' variable names originated in the GKE provider, and are inconsitently used in other providers.

'instance_count' and 'instance_type' provide a consistent, abstracted naming scheme that is also consistent with _blue-horizon_'s cluster sizing UI:
https://github.com/SUSE-Enceladus/blue-horizon/pull/9/files#diff-89d44216929d0c07c5055a046f352a7aR24-R25