### PR TITLE
Templatize the cert issuer config

### DIFF
--- a/aks/README.md
+++ b/aks/README.md
@@ -1,9 +1,21 @@
-0. Create an Azure Service Principal
-  ```
-  az ad sp create-for-rbac
-  ```
-  Note the SP must have sufficient privileges, the created account must have at least contributor role. The SP may alternatively be created via the portal by creating an app
-  registration account as assigning the specific role. The data provided as output from this function will be required in the terraform variables.
+0. Prerequisites
+  * Create an Azure Service Principal
+    ```
+    az ad sp create-for-rbac
+    ```
+    Note the SP must have sufficient privileges, the created account must have at least Contributor and DNS Zone Contributor roles. The data provided as output from this function will be required in the terraform variables.
+
+  * Create a Resource Group
+    ```
+    az group create --name $(az_resource_group) --location $(location)
+    ```
+    This resource group will contain all resources of, and in support of your SUSE CAP cluster. Make note of the _name_ and _location_ which must be supplied in terraform variables.
+
+  * Create a DNS zone
+    ```
+    az network dns zone create -g $(az_resource_group) -n $(dns_zone_name)
+    ```
+    The DNS zone will host the cluster's DNS records in a specific domain name. Make note of the _name_ which must be supplied in terraform variables. See https://docs.microsoft.com/en-us/azure/dns/ for details on setting up a DNS zone.
 
 1. Create a `terraform.tfvars` or update the `terraform.tfvars.json` (should be in your `.gitignore` or outside source control as it contains sensitive information) file with the following information
   - `location` (Azure region - eastus, westus etc.)
@@ -22,6 +34,8 @@
   - `node_count` ("2" this is the number of worker nodes)
   - `machine_type` ("Standard_D4s_v3"  this is the node type used for the provisioned k8s workers/minion)
   - `cap_domain` ("xxxxxxx" this is the domain variable that will be used in the scf-config-values.yaml)
+  - `email` (email address to send TLS certificate notifications to)
+  - `dns_zone_name` (name of the Azure DNS Zone created for the cluster)
 
 2. In the helm chart values yaml use the following values to allow `cert-manager` to generate certificates for the ingress endpoints, you may use the scf-config-values.yaml as a reference:
 
@@ -37,14 +51,12 @@
 
   If you change the values of the annotations above you'll need to make corresponding changes in the cert-manager setup (see the `cert-manager.tf` template and the associated scripts)
 
-3. Make appropriate substituions in the `le-prod-cert-issuer.yaml.template` and rename it to `le-prod-cert-issuer.yaml`.
+3. `terraform init`
 
-4. `terraform init`
+4. `terraform plan -out <PLAN-path>`
 
-5. `terraform plan -out <PLAN-path>`
+5. `terraform apply plan <PLAN-path>`
 
-6. `terraform apply plan <PLAN-path>`
+6. A kubeconfig named `aksk8scfg` is generated in the same directory TF is run from. Set your `KUBECONFIG` env var to point to this file.
 
-7. A kubeconfig named `aksk8scfg` is generated in the same directory TF is run from. Set your `KUBECONFIG` env var to point to this file.
-
-8. The `helm install`s should have been triggered as part of step 5. Check the pods in uaa, scf, stratos and metrics namespace to make sure they all come up and are ready.
+7. The `helm install`s should have been triggered as part of step 5. Check the pods in uaa, scf, stratos and metrics namespace to make sure they all come up and are ready.

--- a/aks/deploy_metrics.sh
+++ b/aks/deploy_metrics.sh
@@ -1,10 +1,6 @@
 #! /bin/sh
-#az login --service-principal -u $ARM_CLIENT_ID -p $ARM_CLIENT_SECRET --tenant $ARM_TENANT_ID
-#az aks get-credentials -n ${CLUSTER_NAME} -g ${RESOURCE_GROUP} -a -f /tmp/aksk8scfg2
 export KUBECONFIG=./aksk8scfg
 APISRV="$(kubectl cluster-info| head -n 1|grep -o ' at .*$'| cut -f3 -d' '| cut -f3 -d'/'|cut -f1 -d':')"
 cat $METRICS_FILE $SCF_FILE > ./capConfigurationFile.yaml
 sed -i "s/MASTER_URL/https:\/\/$APISRV/g"  ./capConfigurationFile.yaml
-helm install suse/metrics     --name susecf-metrics     --namespace metrics    --values ./capConfigurationFile.yaml 
-#rm -f /tmp/aksk8scfg2
-#az logout
+helm install suse/metrics     --name susecf-metrics     --namespace metrics    --values ./capConfigurationFile.yaml

--- a/aks/ext-dns-metrics-svc-annotate.sh
+++ b/aks/ext-dns-metrics-svc-annotate.sh
@@ -1,7 +1,3 @@
 #! /bin/sh
-#az login --service-principal -u $ARM_CLIENT_ID -p $ARM_CLIENT_SECRET --tenant $ARM_TENANT_ID
-#az aks get-credentials -n ${CLUSTER_NAME} -g ${RESOURCE_GROUP} -a -f /tmp/aksk8scfg
 export KUBECONFIG=./aksk8scfg
 kubectl annotate svc susecf-metrics-metrics-nginx -n metrics  "external-dns.alpha.kubernetes.io/hostname=metrics.${DOMAIN}"
-#rm -f /tmp/aksk8scfg
-#az logout

--- a/aks/ext-dns-stratos-svc-annotate.sh
+++ b/aks/ext-dns-stratos-svc-annotate.sh
@@ -1,7 +1,3 @@
 #! /bin/sh
-#az login --service-principal -u $ARM_CLIENT_ID -p $ARM_CLIENT_SECRET --tenant $ARM_TENANT_ID
-#az aks get-credentials -n ${CLUSTER_NAME} -g ${RESOURCE_GROUP} -a -f /tmp/aksk8scfg
 export KUBECONFIG=./aksk8scfg
 kubectl annotate svc susecf-console-ui-ext -n stratos  "external-dns.alpha.kubernetes.io/hostname=stratos.${DOMAIN}"
-#rm -f /tmp/aksk8scfg
-#az logout

--- a/aks/le-cert-issuer.yaml.tmpl
+++ b/aks/le-cert-issuer.yaml.tmpl
@@ -1,12 +1,12 @@
-apiVersion: certmanager.k8s.io/v1alpha1
+apiVersion: cert-manager.io/v1alpha2
 kind: ClusterIssuer
 metadata:
   name: letsencrypt-prod
 spec:
   acme:
     # Replace with your email address so you can be notified of expiring certificates
-    email: #Email
-    # This is using letsencrypt production so beware of rate-limiting! 
+    email: ${email}
+    # This is using letsencrypt production so beware of rate-limiting!
     server: https://acme-v02.api.letsencrypt.org/directory
     privateKeySecretRef:
       # The secret that holds the generated private key used to communicate with Let's Encrypt
@@ -16,15 +16,14 @@ spec:
       - name: azuredns
         azuredns:
           # Service principal clientId (also called appId)
-          clientID: #AZ_CLIENT_ID
+          clientID: ${client_id}
           # A secretKeyRef to a service principal ClientSecret (password)
-          # ref: https://docs.microsoft.com/en-us/azure/container-service/kubernetes/container-service-kubernetes-service-principal 
+          # ref: https://docs.microsoft.com/en-us/azure/container-service/kubernetes/container-service-kubernetes-service-principal
           clientSecretSecretRef:
             name: azuredns-config
             key: CLIENT_SECRET
           # Azure subscription Id
-          subscriptionID: #AZ_SUB_ID
-          tenantID: #AZ_TENANT_ID
-          resourceGroupName: #AZ_RESOURCE_GROUP(where DNS zone is)
-          hostedZoneName: #DNS_ZONE_NAME
-
+          subscriptionID: ${subscription_id}
+          tenantID: ${tenant_id}
+          resourceGroupName: ${az_resource_group}
+          hostedZoneName: ${dns_zone_name}

--- a/aks/setup_cert_issuer.sh
+++ b/aks/setup_cert_issuer.sh
@@ -5,7 +5,7 @@ az aks get-credentials -n ${CLUSTER_NAME} -g ${RESOURCE_GROUP} -a -f /tmp/aksk8s
 export KUBECONFIG=/tmp/aksk8scfg
 
 kubectl create secret generic -n cert-manager azuredns-config --from-literal=CLIENT_SECRET=${AZ_CERT_MGR_SP_PWD}
-kubectl apply -f le-prod-cert-issuer.yaml
+kubectl apply -f le-cert-issuer.yaml
 
 rm -f /tmp/aksk8scfg
 az logout

--- a/aks/setup_cert_issuer.sh
+++ b/aks/setup_cert_issuer.sh
@@ -1,11 +1,4 @@
 #! /bin/sh
-az login --service-principal -u $ARM_CLIENT_ID -p $ARM_CLIENT_SECRET --tenant $ARM_TENANT_ID
-
-az aks get-credentials -n ${CLUSTER_NAME} -g ${RESOURCE_GROUP} -a -f /tmp/aksk8scfg --subscription $ARM_SUBSCRIPTION_ID
-export KUBECONFIG=/tmp/aksk8scfg
-
+export KUBECONFIG=./aksk8scfg
 kubectl create secret generic -n cert-manager azuredns-config --from-literal=CLIENT_SECRET=${AZ_CERT_MGR_SP_PWD}
 kubectl apply -f le-cert-issuer.yaml
-
-rm -f /tmp/aksk8scfg
-az logout

--- a/aks/setup_cert_manager.sh
+++ b/aks/setup_cert_manager.sh
@@ -1,8 +1,5 @@
 #!/bin/sh
-az login --service-principal -u $ARM_CLIENT_ID -p $ARM_CLIENT_SECRET --tenant $ARM_TENANT_ID
-
-az aks get-credentials -n ${CLUSTER_NAME} -g ${RESOURCE_GROUP} -a -f /tmp/aksk8scfg --subscription $ARM_SUBSCRIPTION_ID
-export KUBECONFIG=/tmp/aksk8scfg
+export KUBECONFIG=./aksk8scfg
 
 # Create the namespace for cert-manager
 kubectl create namespace cert-manager
@@ -12,8 +9,3 @@ kubectl label namespace cert-manager certmanager.k8s.io/disable-validation=true
 
 # Install the CustomResourceDefinition resources separately
 kubectl apply -f https://raw.githubusercontent.com/jetstack/cert-manager/release-0.8/deploy/manifests/00-crds.yaml
-
-rm -f /tmp/aksk8scfg
-az logout
-
-

--- a/aks/variables.tf
+++ b/aks/variables.tf
@@ -67,3 +67,13 @@ variable "stratos_metrics_config_file" {
 variable "cap_domain" {
     type = "string"
 }
+
+variable "email" {
+    type = "string"
+    description = "email address to send certificate notifications to"
+}
+
+variable "dns_zone_name" {
+    type = "string"
+    description = "name of the Azure DNS Zone created for the cluster"
+}


### PR DESCRIPTION
* Generate le-cert-issuer.yaml, for use in setting up Let's Encrypt certificates via k8s provider.
* Append documentation to explicitly required an Azure DNS Zone set up in advance.