### PR TITLE
set gke cluster name via tf var, needed for CI

### DIFF
--- a/gke/main.tf
+++ b/gke/main.tf
@@ -1,12 +1,5 @@
-resource "random_string" "cluster_name" {
-  length  = 8
-  special = false
-  upper   = false
-  number  = false
-}
-
 resource "google_container_cluster" "gke-cluster" {
-  name     = "cap-${random_string.cluster_name.result}"
+  name     = "${var.cluster_name}"
   location = "${var.location}"
 
   # We can't create a cluster with no node pool defined, but we want to only use

--- a/gke/terraform.tfvars.template
+++ b/gke/terraform.tfvars.template
@@ -1,3 +1,4 @@
+cluster_name        =   "placeholder" #Kubernetes cluster name
 project             =   "placeholder" #GCP project id
 location            =   "placeholder" #GCP region
 node_pool_name      =   "placeholder" #Name for your nodepool

--- a/gke/variables.tf
+++ b/gke/variables.tf
@@ -1,3 +1,7 @@
+variable "cluster_name" {
+    type = "string"
+}
+
 variable "location" {
     default = "us-central1-a"
 }


### PR DESCRIPTION
User was only required to provide a label for gke cluster. With this PR, user is now expected to provide cluster name along with label. This is required for CI work, where we want to control cluster name and label. 