### PR TITLE
Provide EKS cluster name via dedicated tf output

### DIFF
--- a/eks/outputs.tf
+++ b/eks/outputs.tf
@@ -36,3 +36,7 @@ KUBECONFIG
 output "kubeconfig" {
   value = "${local.kubeconfig}"
 }
+
+output "cluster-name" {
+  value = "${module.eks.eks-cluster-name}"
+}


### PR DESCRIPTION
Ref: https://jira.suse.com/browse/CAP-1395

The information will be retrieved by catapult's eks backend and saved into a file, for pickup by catapult's user, like a CI pipeline.

See https://github.com/SUSE/catapult/pull/190
