### PR TITLE
Fix external-dns

### DIFF
--- a/aks/external-dns.tf
+++ b/aks/external-dns.tf
@@ -17,8 +17,8 @@ data "helm_repository" "external-dns-repo" {
 
 resource "helm_release" "external-dns" {
     name = "cap-external-dns"
-    repository = data.helm_repository.external-dns-repo.metadata[0].name
-    chart = "bitnami/external-dns"
+    repository = data.helm_repository.external-dns-repo.metadata[0].url
+    chart = "external-dns"
     wait = "false"
 
     set {

--- a/eks/modules/services/external-dns.tf
+++ b/eks/modules/services/external-dns.tf
@@ -5,8 +5,8 @@ data "helm_repository" "external-dns-repo" {
 
 resource "helm_release" "external-dns" {
     name = "cap-external-dns"
-    repository = data.helm_repository.external-dns-repo.metadata[0].name
-    chart = "bitnami/external-dns"
+    repository = data.helm_repository.external-dns-repo.metadata[0].url
+    chart = "external-dns"
     wait = "false"
 
     set {

--- a/gke/external-dns.tf
+++ b/gke/external-dns.tf
@@ -17,8 +17,8 @@ data "helm_repository" "external-dns-repo" {
 
 resource "helm_release" "external-dns" {
     name = "cap-external-dns"
-    repository = data.helm_repository.external-dns-repo.metadata[0].name
-    chart = "bitnami/external-dns"
+    repository = data.helm_repository.external-dns-repo.metadata[0].url
+    chart = "external-dns"
     wait = "false"
 
     set {


### PR DESCRIPTION
When installing external-dns, it doesn't do helm update:
  Error: failed to download "bitnami/external-dns" (hint: running `helm repo update` may help)
See: https://github.com/terraform-providers/terraform-provider-helm/issues/438

Using the .url instead of .name (and therefore changing the chart name too)
fixes it.