### PR TITLE
Set external-dns policy to sync, deletes DNS entries automatically

### DIFF
--- a/aks/external-dns.tf
+++ b/aks/external-dns.tf
@@ -44,6 +44,12 @@ resource "helm_release" "external-dns" {
         name = "rbac.create"
         value = "true"
     }
+
+    set {
+      name = "policy"
+      value = "sync"
+    }
+
     depends_on = [kubernetes_secret.azure_dns_sp_creds]
 }
 

--- a/eks/modules/services/external-dns.tf
+++ b/eks/modules/services/external-dns.tf
@@ -49,5 +49,10 @@ resource "helm_release" "external-dns" {
         value = "true"
     }
 
+    set {
+      name = "policy"
+      value = "sync"
+    }
+
     depends_on = [kubernetes_config_map.aws_auth]
 }

--- a/gke/external-dns.tf
+++ b/gke/external-dns.tf
@@ -44,6 +44,11 @@ resource "helm_release" "external-dns" {
         value = "true"
     }
 
+    set {
+      name = "policy"
+      value = "sync"
+    }
+
     depends_on = [null_resource.post_processor]
 
 }


### PR DESCRIPTION
Thanks to @satadruroy.

See:
https://github.com/helm/charts/blob/34b7037addd517f83e242e72e5c05d1fe90ccc80/stable/external-dns/values.yaml#L321
https://github.com/kubernetes-sigs/external-dns/blob/490ff5dd4ec719a7f35779bf547eb5532105a9bd/plan/policy.go#L39