### PR TITLE
Remove outputting kubeconfig from AKS template.

### DIFF
--- a/aks/main.tf
+++ b/aks/main.tf
@@ -45,10 +45,6 @@ locals {
   k8scfg = azurerm_kubernetes_cluster.k8s.kube_config_raw
 }
 
-output "kube_config" {
-  value = local.k8scfg
-}
-
 resource "local_file" "k8scfg" {
   content = local.k8scfg
   filename = "aksk8scfg"


### PR DESCRIPTION
This if kept will spill over `kubeconfig` in console logs.