### PR TITLE
Default EKS instance_type to t3.xlarge

### DIFF
--- a/eks/variables.tf
+++ b/eks/variables.tf
@@ -25,6 +25,7 @@ variable "cluster_labels" {
 
 variable "instance_type" {
     type = string
+    default = "t3.xlarge"
 }
 
 


### PR DESCRIPTION
Needed for passing CATS.

Untested (but simple enough).