### PR TITLE
Add Calico as networking plugin to GKE

### DIFF
--- a/gke/main.tf
+++ b/gke/main.tf
@@ -27,7 +27,11 @@ resource "google_container_cluster" "gke-cluster" {
     network_policy_config {
       disabled = false
     }
+  }
 
+  network_policy {
+    enabled  = true
+    provider = "CALICO"
   }
 }
 

--- a/gke/main.tf
+++ b/gke/main.tf
@@ -8,7 +8,7 @@ resource "google_container_cluster" "gke-cluster" {
   remove_default_node_pool = true
 
   initial_node_count = 1
-  resource_labels = var.cluster_labels
+  resource_labels    = var.cluster_labels
 
   # Setting an empty username and password explicitly disables basic auth
   master_auth {

--- a/gke/main.tf
+++ b/gke/main.tf
@@ -24,6 +24,9 @@ resource "google_container_cluster" "gke-cluster" {
     horizontal_pod_autoscaling {
       disabled = true
     }
+    network_policy_config {
+      disabled = false
+    }
 
   }
 }


### PR DESCRIPTION
Needed for being able to set NetworkPolicies and provide airgap, for airgap installations and cats internetless.