### PR TITLE
gke: Add labels to the external address

### DIFF
--- a/gke/gcp-static-ext-address.tf
+++ b/gke/gcp-static-ext-address.tf
@@ -1,4 +1,7 @@
 resource "google_compute_address" "ingress-ext-address" {
+  # Use the google-beta provider to get support for labels
+  provider = google-beta
   name = "ingress-address-${var.cluster_name}"
+  labels = var.cluster_labels
 }
 

--- a/gke/provider.tf
+++ b/gke/provider.tf
@@ -7,3 +7,11 @@ provider "google" {
     zone        = var.location
 }
 
+# Also have a google-beta block to use it for gcp-static-ext-address.tf
+provider "google-beta" {
+	version 	= "~> 3.0"
+	credentials = var.gke_sa_key
+	project     = var.project
+    zone        = var.location
+}
+


### PR DESCRIPTION
This requires opting into the google-beta provider for the google_compute_address resource.  Use that provider _only_ for that resource, since we don't need to use it for anything else.

This is helpful for CI, so we can better track where the IP address are coming from (and automatically delete them if they're orphaned).