### PR TITLE
fix: GKE: Use upstream ingress-nginx

### DIFF
--- a/gke/nginx-ingress.tf
+++ b/gke/nginx-ingress.tf
@@ -1,39 +1,29 @@
 # Add Kubernetes Stable Helm charts repo
-data "helm_repository" "bitnami" {
-  name = "bitnami"
-  url  = "https://charts.bitnami.com/bitnami"  
+data "helm_repository" "ingress-nginx" {
+  name = "ingress-nginx"
+  url  = "https://kubernetes.github.io/ingress-nginx"  
 }
 
 # Install Nginx Ingress using Helm Chart
 resource "helm_release" "nginx_ingress" {
   name       = "nginx-ingress"
-  repository = data.helm_repository.bitnami.metadata[0].url
-  chart      = "nginx-ingress-controller"
+  repository = data.helm_repository.ingress-nginx.metadata[0].url
+  chart      = "ingress-nginx"
   wait       = "false"
 
-/*
-# rbac.create is set to true by default in the bitnami nginx chart.
   set {
-    name  = "rbac.create"
-    value = "true"
-  }
-*/  
-# Note if you use the chart from kube helm repository the following must be "controller.service.externalTrafficPolicy"
-
-  set {
-    name  = "service.externalTrafficPolicy"
+    name  = "controller.service.externalTrafficPolicy"
     value = "Local"
   }
 
-# Note if you use the chart from kube helm repository the following must be "controller.publishService.enabled"
   set {
-      name =  "publishService.enabled"
+      name =  "controller.publishService.enabled"
       value = "true"
   }
-# Make sure the nginx LB service gets a static, non-ephemeral (regional) IP.
 
+  # Make sure the nginx LB service gets a static, non-ephemeral (regional) IP.
   set {
-      name = "service.loadBalancerIP"
+      name = "controller.service.loadBalancerIP"
       value = google_compute_address.ingress-ext-address.address
   }
 


### PR DESCRIPTION
The upstream chart uses images from `k8s.gcr.io` which will let us get away from Docker Hub quotas.

Note that this currently isn't being tested by KubeCF CI as far as I can tell (it seems to always use load balancer).