### PR TITLE
Fix external dns by bumping helm provider to 2.0.2

### DIFF
--- a/gke/external-dns.tf
+++ b/gke/external-dns.tf
@@ -9,15 +9,10 @@ resource "kubernetes_secret" "google_dns_sa_creds" {
   }
 }
 
-data "helm_repository" "external-dns-repo" {
-  name = "external-dns-chart-repo"
-  url  = "https://charts.bitnami.com/bitnami"
-}
-
 
 resource "helm_release" "external-dns" {
     name = "cap-external-dns"
-    repository = data.helm_repository.external-dns-repo.metadata[0].url
+    repository = "https://charts.bitnami.com/bitnami"
     chart = "external-dns"
     wait = "false"
 

--- a/gke/helm.tf
+++ b/gke/helm.tf
@@ -2,7 +2,6 @@ provider "helm" {
     version = "~> 2.0.2"
 
   kubernetes {   
-    load_config_file = false
     host = "https://${google_container_cluster.gke-cluster.endpoint}"
     cluster_ca_certificate = base64decode(google_container_cluster.gke-cluster.master_auth.0.cluster_ca_certificate)
     token = data.google_client_config.current.access_token

--- a/gke/helm.tf
+++ b/gke/helm.tf
@@ -1,5 +1,5 @@
 provider "helm" {
-    version = "~> 1.0.0"
+    version = "~> 2.0.2"
 
   kubernetes {   
     load_config_file = false

--- a/gke/nginx-ingress.tf
+++ b/gke/nginx-ingress.tf
@@ -1,13 +1,7 @@
-# Add Kubernetes Stable Helm charts repo
-data "helm_repository" "ingress-nginx" {
-  name = "ingress-nginx"
-  url  = "https://kubernetes.github.io/ingress-nginx"  
-}
-
 # Install Nginx Ingress using Helm Chart
 resource "helm_release" "nginx_ingress" {
   name       = "nginx-ingress"
-  repository = data.helm_repository.ingress-nginx.metadata[0].url
+  repository = "https://kubernetes.github.io/ingress-nginx"
   chart      = "ingress-nginx"
   wait       = "false"
 


### PR DESCRIPTION
-  Bump helm provider to 2.0.2. `external-dns` chart now supports only helm >=3.0.1.
   bitnami/charts#5091
-  Drop helm_repository data, deprecated in helm resource >=2.0
   https://registry.terraform.io/providers/hashicorp/helm/1.3.0/docs/data-sources/repository
-  Drop load_config_file config in helm.tf
   Not needed anymore, default to reading KUBECONFIG
   https://registry.terraform.io/providers/hashicorp/helm/latest/docs#file-config


